### PR TITLE
Fix vulnerabilities in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A promise-based AngularJS service that allows you to work with REST endpoints defined with Swagger.",
   "main": "./dist/angular-swaggerific.min.js",
   "dependencies": {
-    "grunt": "^0.4.5"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Gulp 0.4.5 has many security issues.

It is a `devDependency`, so it shouldn't appear in `dependencies`.

This fixes 25 `npm audit` vulnerabilities in `tr-web`.